### PR TITLE
Run tests against Python 3.5

### DIFF
--- a/README
+++ b/README
@@ -161,15 +161,15 @@ Tests
 ------------------------------------------------------------------------
 
 The library is tested against Python 2.6, Python 2.7, Python 3.2, Python 3.3,
-and Python 3.4. A tox (https://testrun.org/tox/latest/) configuration file is 
-included to easily run tests against each of these environments. To run tests 
-against all environments, install tox and run:
+Python 3.4, and Python 3.5. A tox (https://testrun.org/tox/latest/)
+configuration file is included to easily run tests against each of these
+environments. To run tests against all environments, install tox and run:
 
 >>> tox
 
 To run against a specific environment, use the `-e` flag:
 
->>> tox -e py33
+>>> tox -e py35
 
 ------------------------------------------------------------------------
 LICENSE

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 downloadcache = {toxworkdir}/_download/
-envlist = py34, py33, py32, py27, py26
+envlist = py35, py34, py33, py32, py27, py26
 
 [testenv]
 commands = {envpython} test/all_tests.py


### PR DESCRIPTION
Python 3.5 was released since #11 was made. Thanks for merging that pull request!