### PR TITLE
NOAA URL update

### DIFF
--- a/misc/getstation.py
+++ b/misc/getstation.py
@@ -6,7 +6,7 @@ import getopt
 import datetime
 import urllib
 
-BASE_URL = "http://weather.noaa.gov/pub/data/observations/metar/stations"
+BASE_URL = "http://tgftp.nws.noaa.gov/data/observations/metar/stations"
 
 def usage():
   print "Usage:  $0 "


### PR DESCRIPTION
URL:
http://weather.noaa.gov/pub/data/observations/metar/stations
is not working and should be updated to:
http://tgftp.nws.noaa.gov/data/observations/metar/stations
