### PR TITLE
Provide more information on ParserError

### DIFF
--- a/metar/Metar.py
+++ b/metar/Metar.py
@@ -407,7 +407,7 @@ class Metar(object):
           raise err
       if self._unparsed_groups:
           code = ' '.join(self._unparsed_groups)
-          raise ParserError("Unparsed groups in body: "+code)
+          raise ParserError("Unparsed groups in body '"+code+"' while processing '"+metarcode+"'")
 
   def _do_trend_handlers(self, code):
       for pattern, handler, repeatable in Metar.trend_handlers:


### PR DESCRIPTION
On a ParserError with unparsed groups it is helpful to also show the metarcode to avoid costly debugging.