### PR TITLE
Update Datatypes.py

### DIFF
--- a/metar/Datatypes.py
+++ b/metar/Datatypes.py
@@ -440,7 +440,7 @@ class position(object):
     long1 = self.longitude
     lat2 = position2.latitude
     long2 = position2.longitude
-    a = sin(0.5(lat2-lat1)) + cos(lat1)*cos(lat2)*sin(0.5*(long2-long1)**2)
+    a = sin(0.5*(lat2-lat1)) + cos(lat1)*cos(lat2)*sin(0.5*(long2-long1)**2)
     c = 2.0*atan(sqrt(a)*sqrt(1.0-a))
     d = distance(earth_radius*c,"M")
     return d


### PR DESCRIPTION
Solving the metar/Datatypes.py:443: SyntaxWarning: 'float' object is not callable (on Python 3.9.13)
Thank you